### PR TITLE
Remove do queue

### DIFF
--- a/ionizer/ops.py
+++ b/ionizer/ops.py
@@ -43,8 +43,8 @@ class GPI(Operation):
     num_params = 1
     ndim_params = (0,)
 
-    def __init__(self, phi, wires, do_queue=True, id=None):
-        super().__init__(phi, wires=wires, do_queue=do_queue, id=id)
+    def __init__(self, phi, wires, id=None):
+        super().__init__(phi, wires=wires, id=id)
 
     @staticmethod
     def compute_matrix(phi):  # pylint: disable=arguments-differ
@@ -90,8 +90,8 @@ class GPI2(Operation):
     num_params = 1
     ndim_params = (0,)
 
-    def __init__(self, phi, wires, do_queue=True, id=None):
-        super().__init__(phi, wires=wires, do_queue=do_queue, id=id)
+    def __init__(self, phi, wires, id=None):
+        super().__init__(phi, wires=wires, id=id)
 
     @staticmethod
     def compute_matrix(phi):  # pylint: disable=arguments-differ
@@ -141,8 +141,8 @@ class MS(Operation):
     num_wires = 2
     num_params = 0
 
-    def __init__(self, wires, do_queue=True, id=None):
-        super().__init__(wires=wires, do_queue=do_queue, id=id)
+    def __init__(self, wires, id=None):
+        super().__init__(wires=wires, id=id)
 
     @staticmethod
     def compute_matrix():  # pylint: disable=arguments-differ

--- a/ionizer/transforms.py
+++ b/ionizer/transforms.py
@@ -127,7 +127,7 @@ def virtualize_rz_gates(tape):
     Args:
         tape (pennylane.QuantumTape): A quantum tape to transform.
     """
-    list_copy = tape.operations
+    list_copy = tape.operations.copy()
 
     while len(list_copy) > 0:
         current_gate = list_copy[0]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages, find_namespace_packages
 
 requirements = [
-    "pennylane>=0.29",
+    "pennylane>=0.32",
 ]
 
 setup(
@@ -12,8 +12,7 @@ setup(
     url="https://github.com/QSAR-UBC/ionizer",
     packages=["ionizer", "ionizer.resources"],
     include_package_data=True,
-    package_data={"ionizer.resources": [
-        "double_gate_identities.pkl",
-        "triple_gate_identities.pkl"
-    ]}
+    package_data={
+        "ionizer.resources": ["double_gate_identities.pkl", "triple_gate_identities.pkl"]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
 
 setup(
     name="Ionizer",
-    version="0.1.1",
+    version="0.1.2",
     description="PennyLane tools for compilation into trapped-ion native gates.",
     author="UBC Quantum Software and Algorithms Research Group",
     url="https://github.com/QSAR-UBC/ionizer",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
     packages=["ionizer", "ionizer.resources"],
     include_package_data=True,
     package_data={
-        "ionizer.resources": ["double_gate_identities.pkl", "triple_gate_identities.pkl"]
-    },
+        "ionizer.resources": [
+            "double_gate_identities.pkl",
+            "triple_gate_identities.pkl"
+        ]},
 )


### PR DESCRIPTION
The following have all been completed:

- [x] All new or changed features have a related unit test.

- [x] The entire test suite passes.

- [x] No extra files have been added by mistake, i.e. ```.vscode```.

- [x] Style guidelines have been followed.

- [x] All files have been formatted.

- [x] Documentation and version number (if applicable) have been updated.

- [x] All code changed has been clearly written and commented.

------------------------------------------------------------------------------------------------------------

**Context:**
PennyLane 0.32.0 do_queue has been depreciated. Ionizer does not run on 0.32.0. 

**Description of the Change:**

- Removed do_queue from operations: GPI, GPI2, and MS. 
- Fixed tape being deleted by virtualize_rz_gates transform in 0.32.0 PennyLane

**Benefits:**
works with newer version of PennyLane

**Possible Drawbacks:**
May no longer work with older versions of PennyLane

**Related GitHub Issues:**
N/A