### PR TITLE
Fix transforms to use syntax from v0.33 of PL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ def circuit(x):
 ## Installation
 
 Requirements:
- * PennyLane >= 0.29
+ * PennyLane >= 0.33
 
 The Ionizer is not currently available via a package manager. To install, clone the repository and run
 
@@ -39,6 +39,9 @@ or
 ```
 python setup.py install
 ```
+
+If you need to run Ionizer with a version of PennyLane between 0.29 and 0.32,
+please use version 0.1.2 of the package.
 
 ## Examples
 

--- a/ionizer/transform_utils.py
+++ b/ionizer/transform_utils.py
@@ -54,6 +54,10 @@ def search_and_apply_three_gate_identities(gates_to_apply):
     Args:
         gates_to_apply (List[pennylane.Operation]): A sequence of three gates
              we would like to simplify.
+
+    Returns:
+        List[pennylane.Operation]: The simplified or alternate gate sequence that
+        will be applied within the transform.
     """
     if len(gates_to_apply) != 3:
         raise ValueError(

--- a/ionizer/transforms.py
+++ b/ionizer/transforms.py
@@ -56,6 +56,11 @@ def commute_through_ms_gates(
     Args:
         tape (pennylane.QuantumTape): A quantum tape to transform.
         direction (str): Which direction to push the commuting gates in.
+
+    Returns:
+        qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape],
+        function]: The transformed circuit as described in :func:`qml.transform
+        <pennylane.transform>`.
     """
     if direction not in ["left", "right"]:
         raise ValueError(
@@ -113,7 +118,7 @@ def commute_through_ms_gates(
     new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
-        """A postprocesing function returned by a transform that only converts the batch of results
+        """A postprocessing function returned by a transform that only converts the batch of results
         into a result for a single ``QuantumTape``.
         """
         return results[0]
@@ -136,6 +141,11 @@ def virtualize_rz_gates(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
 
     Args:
         tape (pennylane.QuantumTape): A quantum tape to transform.
+
+    Returns:
+        qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape],
+        function]: The transformed circuit as described in :func:`qml.transform
+        <pennylane.transform>`.
     """
     list_copy = tape.operations.copy()
     new_operations = []
@@ -211,7 +221,7 @@ def virtualize_rz_gates(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
     new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
-        """A postprocesing function returned by a transform that only converts the batch of results
+        """A postprocessing function returned by a transform that only converts the batch of results
         into a result for a single ``QuantumTape``.
         """
         return results[0]
@@ -229,6 +239,11 @@ def single_qubit_fusion_gpi(tape: QuantumTape) -> (Sequence[QuantumTape], Callab
 
     Args:
         tape (pennylane.QuantumTape): A quantum tape to transform.
+
+    Returns:
+        qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape],
+        function]: The transformed circuit as described in :func:`qml.transform
+        <pennylane.transform>`.
     """
     # Make a working copy of the list to traverse
     list_copy = tape.operations.copy()
@@ -300,7 +315,7 @@ def single_qubit_fusion_gpi(tape: QuantumTape) -> (Sequence[QuantumTape], Callab
     new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
-        """A postprocesing function returned by a transform that only converts the batch of results
+        """A postprocessing function returned by a transform that only converts the batch of results
         into a result for a single ``QuantumTape``.
         """
         return results[0]
@@ -319,6 +334,11 @@ def convert_to_gpi(tape: QuantumTape, exclude_list=[]) -> (Sequence[QuantumTape]
         tape (pennylane.QuantumTape): A quantum tape to transform.
         exclude_list (list[str]): A list of names of gates to exclude from
             conversion (see the ionize transform for an example).
+
+    Returns:
+        qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape],
+        function]: The transformed circuit as described in :func:`qml.transform
+        <pennylane.transform>`.
     """
     new_operations = []
 
@@ -335,7 +355,7 @@ def convert_to_gpi(tape: QuantumTape, exclude_list=[]) -> (Sequence[QuantumTape]
     new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
-        """A postprocesing function returned by a transform that only converts the batch of results
+        """A postprocessing function returned by a transform that only converts the batch of results
         into a result for a single ``QuantumTape``.
         """
         return results[0]
@@ -358,6 +378,11 @@ def ionize(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
 
     Args:
         tape (pennylane.QuantumTape): A quantum tape to transform.
+
+    Returns:
+        qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape],
+        function]: The transformed circuit as described in :func:`qml.transform
+        <pennylane.transform>`.
     """
 
     # The tape will first be expanded into known operations
@@ -383,7 +408,7 @@ def ionize(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
     new_tape = type(tape)(optimized_tape[0].operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
-        """A postprocesing function returned by a transform that only converts the batch of results
+        """A postprocessing function returned by a transform that only converts the batch of results
         into a result for a single ``QuantumTape``.
         """
         return results[0]

--- a/ionizer/utils.py
+++ b/ionizer/utils.py
@@ -34,13 +34,12 @@ def are_mats_equivalent(mat1, mat2):
     """
     mat_product = math.dot(mat1, math.conj(math.T(mat2)))
 
-    if math.isclose(mat_product[0, 0], 0.0):
-        mat_product = mat_product / mat_product[0, 1]
-    else:
+    # If the top-left entry is not 0, divide everything by it and test against identity
+    if not math.isclose(mat_product[0, 0], 0.0):
         mat_product = mat_product / mat_product[0, 0]
 
-    if math.allclose(mat_product, math.eye(mat_product.shape[0])):
-        return True
+        if math.allclose(mat_product, math.eye(mat_product.shape[0])):
+            return True
 
     return False
 
@@ -90,8 +89,11 @@ def extract_gpi2_gpi_gpi2_angles(U):
     phase_00 = math.angle(su2_mat[0, 0])
     phase_10 = math.angle(su2_mat[1, 0])
 
+    # Extract the angles; note that we clip the input to the arccos because due
+    # to finite precision, the number may be slightly greater than 1 when their
+    # input matrix element is 0, which would throw an error
     alpha = phase_10 - phase_00 + np.pi
-    beta = math.arccos(math.abs(su2_mat[0, 0])) + phase_10 + np.pi
+    beta = math.arccos(math.clip(math.abs(su2_mat[0, 0]), 0, 1)) + phase_10 + np.pi
     gamma = phase_10 + phase_00 + np.pi
 
     return rescale_angles([gamma, beta, alpha])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pennylane>=0.29
+pennylane>=0.33

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages, find_namespace_packages
 
 requirements = [
-    "pennylane>=0.32",
+    "pennylane>=0.33",
 ]
 
 setup(
     name="Ionizer",
-    version="0.1.2",
+    version="0.2",
     description="PennyLane tools for compilation into trapped-ion native gates.",
     author="UBC Quantum Software and Algorithms Research Group",
     url="https://github.com/QSAR-UBC/ionizer",

--- a/tests/test_transform_utils.py
+++ b/tests/test_transform_utils.py
@@ -1,0 +1,179 @@
+"""
+Test the utility functions for the transpilation transforms. 
+"""
+import pytest
+from functools import partial
+
+import pennylane as qml
+from pennylane import math
+import numpy as np
+
+from ionizer.utils import are_mats_equivalent
+from ionizer.transform_utils import (
+    search_and_apply_two_gate_identities,
+    search_and_apply_three_gate_identities,
+)
+
+from ionizer.ops import GPI, GPI2, MS
+
+
+def _compare_op_lists(ops1, ops2):
+    """Test if two tapes are equal."""
+    assert len(ops1) == len(ops2)
+
+    for op1, op2 in zip(ops1, ops2):
+        assert op1.name == op2.name
+        assert op1.num_params == op2.num_params
+        if op1.num_params > 0:
+            assert math.allclose(op1.data, op2.data)
+
+    return True
+
+
+class TestSearchAndApplyTwoGateIdentities:
+    """Tests that two-gate identities are correctly applied."""
+
+    def test_invalid_length(self):
+        """Test that sequences with incorrect length throw errors."""
+        gates_to_apply = [GPI(0.3, wires=0)]
+
+        with pytest.raises(ValueError, match="Only sets of 2 gates"):
+            _ = search_and_apply_two_gate_identities(gates_to_apply)
+
+        with pytest.raises(ValueError, match="Only sets of 2 gates"):
+            _ = search_and_apply_two_gate_identities(gates_to_apply * 3)
+
+    def test_invalid_gates(self):
+        """Test that when invalid gates are passed, an error is thrown."""
+        expected_gates_to_apply = [qml.Hadamard(wires=0), qml.RX(0.2, wires=0)]
+
+        with pytest.raises(
+            ValueError, match="only 2- and 3-gate circuit identities on GPI/GPI2 gates"
+        ):
+            _ = search_and_apply_two_gate_identities(expected_gates_to_apply)
+
+    def test_double_gpi2_identity_valid_angles(self):
+        """Test that the identity GPI2(x) GPI2(x) = GPI(x) is found."""
+        gates_to_apply = [GPI2(0.3, wires=0), GPI2(0.3, wires=0)]
+
+        obtained_gates_to_apply = search_and_apply_two_gate_identities(gates_to_apply)
+
+        assert len(obtained_gates_to_apply) == 1
+        assert obtained_gates_to_apply[0].name == "GPI"
+        assert math.isclose(obtained_gates_to_apply[0].data[0], 0.3)
+
+        initial_tape = qml.tape.QuantumTape(gates_to_apply, [])
+        obtained_tape = qml.tape.QuantumTape(obtained_gates_to_apply, [])
+        assert are_mats_equivalent(qml.matrix(initial_tape), qml.matrix(obtained_tape))
+
+    def test_double_gpi2_identity_invalid_angles(self):
+        """Test that if angles are different, GPI2(x) GPI2(x) = GPI(x) is not used."""
+        gates_to_apply = [GPI2(0.3, wires=0), GPI2(0.4, wires=0)]
+
+        obtained_gates_to_apply = search_and_apply_two_gate_identities(gates_to_apply)
+
+        assert _compare_op_lists(gates_to_apply, obtained_gates_to_apply)
+
+    def test_double_gpi2_identity_valid_angles_different_wires(self):
+        """Test that GPI2(x) GPI2(x) = GPI(x) is not used if wires are different."""
+        gates_to_apply = [GPI2(0.3, wires=0), GPI2(0.4, wires=1)]
+
+        with pytest.raises(ValueError, match="Gates must share wires to find identities."):
+            _ = search_and_apply_two_gate_identities(gates_to_apply)
+
+    @pytest.mark.parametrize(
+        "input_ops,expected_ops",
+        [
+            ([GPI2(0, wires=0), GPI(0, wires=0)], [GPI2(-np.pi, wires=0)]),
+            ([GPI2(0, wires=2), GPI2(np.pi, wires=2)], []),
+            ([GPI2(np.pi, wires=0), GPI2(0, wires=0)], []),
+            ([GPI2(np.pi, wires=1), GPI(0, wires=1)], [GPI2(0, wires=1)]),
+        ],
+    )
+    def test_valid_identities(self, input_ops, expected_ops):
+        """Test a set of known identities."""
+        obtained_ops = search_and_apply_two_gate_identities(input_ops)
+        assert _compare_op_lists(obtained_ops, expected_ops)
+
+        # Add identity op to account for cases where the simplification returned is identity
+        initial_tape = qml.tape.QuantumTape(input_ops, [])
+        obtained_tape = qml.tape.QuantumTape(
+            [qml.Identity(wires=input_ops[0].wires)] + obtained_ops, []
+        )
+        assert are_mats_equivalent(qml.matrix(initial_tape), qml.matrix(obtained_tape))
+
+
+class TestSearchAndApplyThreeGateIdentities:
+    """Tests that three-gate identities are correctly applied."""
+
+    def test_invalid_length(self):
+        """Test that sequences with incorrect length throw errors."""
+        gates_to_apply = [GPI(0.3, wires=0)]
+
+        with pytest.raises(ValueError, match="Only sets of 3 gates"):
+            _ = search_and_apply_three_gate_identities(gates_to_apply)
+
+        with pytest.raises(ValueError, match="Only sets of 3 gates"):
+            _ = search_and_apply_three_gate_identities(gates_to_apply * 4)
+
+    def test_invalid_gates(self):
+        """Test that when invalid gates are passed, an error is thrown."""
+        expected_gates_to_apply = [
+            qml.Hadamard(wires=0),
+            qml.Hadamard(wires=0),
+            qml.RX(0.2, wires=0),
+        ]
+
+        with pytest.raises(
+            ValueError, match="only 2- and 3-gate circuit identities on GPI/GPI2 gates"
+        ):
+            _ = search_and_apply_three_gate_identities(expected_gates_to_apply)
+
+    def test_invalid_identity(self):
+        """Test that if angles are different, no identity gets applied"""
+        gates_to_apply = [GPI2(0.3, wires=0), GPI2(0.4, wires=0), GPI2(0.5, wires=0)]
+
+        obtained_gates_to_apply = search_and_apply_three_gate_identities(gates_to_apply)
+
+        assert _compare_op_lists(gates_to_apply, obtained_gates_to_apply)
+
+    def test_valid_identity_different_wires(self):
+        """Test that for a valid identity on inconsistent wires, no identity gets applied"""
+        gates_to_apply = [GPI2(0, wires=0), GPI(np.pi / 4, wires=1), GPI2(0, wires=0)]
+
+        with pytest.raises(ValueError, match="Gates must share wires to find identities."):
+            _ = search_and_apply_three_gate_identities(gates_to_apply)
+
+    @pytest.mark.parametrize(
+        "input_ops,expected_ops",
+        [
+            ([GPI2(np.pi, wires=0), GPI(0, wires=0), GPI2(-np.pi, wires=0)], []),  # Simplifies to I
+            (
+                [GPI2(0, wires=0), GPI(np.pi / 4, wires=0), GPI2(0, wires=0)],
+                [GPI2(-np.pi / 2, wires=0)],
+            ),  # 3-gate identity
+            (
+                [GPI2(0, wires=0), GPI2(np.pi, wires=0), GPI2(0.3, wires=0)],
+                [GPI2(0.3, wires=0)],
+            ),  # First two gates only
+            (
+                [GPI2(0.3, wires=0), GPI2(0, wires=0), GPI2(np.pi, wires=0)],
+                [GPI2(0.3, wires=0)],
+            ),  # Second two gates only
+            (
+                [GPI2(-np.pi / 2, wires=0), GPI(-np.pi / 4, wires=0), GPI2(-np.pi / 2, wires=0)],
+                [GPI2(-np.pi, wires=0)],
+            ),  # 3-gate identity
+        ],
+    )
+    def test_valid_identities(self, input_ops, expected_ops):
+        """Test a set of known identities."""
+        obtained_ops = search_and_apply_three_gate_identities(input_ops)
+        assert _compare_op_lists(obtained_ops, expected_ops)
+
+        # Add identity op to account for cases where the simplification returned is identity
+        initial_tape = qml.tape.QuantumTape(input_ops, [])
+        obtained_tape = qml.tape.QuantumTape(
+            [qml.Identity(wires=input_ops[0].wires)] + obtained_ops, []
+        )
+        assert are_mats_equivalent(qml.matrix(initial_tape), qml.matrix(obtained_tape))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,9 +92,6 @@ class TestExtractGPIGPI2Angles:
     def test_extract_gpi_gpi2_angles(self, U):
         """Test that extracting GPI/GPI2 angles yields the correct operation."""
         gamma, beta, alpha = extract_gpi2_gpi_gpi2_angles(U)
-        print(gamma)
-        print(beta)
-        print(alpha)
 
         with qml.tape.QuantumTape() as tape:
             GPI2(gamma, wires=0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,6 +92,9 @@ class TestExtractGPIGPI2Angles:
     def test_extract_gpi_gpi2_angles(self, U):
         """Test that extracting GPI/GPI2 angles yields the correct operation."""
         gamma, beta, alpha = extract_gpi2_gpi_gpi2_angles(U)
+        print(gamma)
+        print(beta)
+        print(alpha)
 
         with qml.tape.QuantumTape() as tape:
             GPI2(gamma, wires=0)


### PR DESCRIPTION
**Context:** In the newest version of PennyLane (v0.33), there are some differences in how transforms are structured and called. A [user noticed this](https://discuss.pennylane.ai/t/the-new-pennylane-v0-33-cannot-support-ionizer/3613).

**Description of the Change:** All transforms have been updated to use the new syntax. Code has been adapted from the updated optimization transforms in PennyLane. This PR also includes a number of  new unit tests to take into account some missing coverage in the previous version.

**Benefits:** Future-proofing and improved test coverage.

**Possible Drawbacks:** Users will have to update their code to the newest version of PennyLane, or use the older version of the Ionizer.

**Related GitHub Issues:** #5 
