### PR TITLE
Updates to verify support for PennyLane v0.36.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install black pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Format with black
+      run: |
+        black -l 100 ionizer/*.py tests/*.py
+    - name: Test with pytest
+      run: |
+        pytest tests/test_*.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "update-tests" ]
 
 jobs:
   build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,6 +20,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install black pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install .
     - name: Format with black
       run: |
         black -l 100 ionizer/*.py tests/*.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,6 +33,11 @@ jobs:
     - name: Format with black
       run: |
         black -l 100 ionizer/*.py tests/*.py
+    - name: Add & Commit
+      uses: EndBug/add-and-commit@v9.1.4
+      with:
+        add: "ionizer/*.py tests/*.py"
+        message: "Auto-format with black"
     - name: Test with pytest
       run: |
         pytest tests/test_*.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main", "update-tests" ]
+    branches: [ "main", "rc-0.*" ]
 
 jobs:
   build:

--- a/ionizer/identity_hunter.py
+++ b/ionizer/identity_hunter.py
@@ -2,6 +2,7 @@
 Submodule to generate and store a database of circuit identities involving
 up to 3 GPI/GPI2 gates.
 """
+
 from importlib.resources import files
 
 from itertools import product

--- a/ionizer/ops.py
+++ b/ionizer/ops.py
@@ -39,6 +39,7 @@ class GPI(Operation):
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 1
     ndim_params = (0,)
@@ -138,6 +139,7 @@ class MS(Operation):
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 0
 

--- a/tests/test_decompositions.py
+++ b/tests/test_decompositions.py
@@ -79,7 +79,9 @@ class TestDecompositions:
     def test_non_parametric_decompositions(self, gate, decomp_function):
         """Test decompositions of non-parametric operations."""
         expected_mat = gate.compute_matrix()
-        obtained_mat = qml.matrix(decomp_function)(wires=range(gate.num_wires))
+        obtained_mat = qml.matrix(decomp_function, wire_order=range(gate.num_wires))(
+            wires=range(gate.num_wires)
+        )
         mat_product = qml.math.dot(expected_mat, qml.math.conj(qml.math.T(obtained_mat)))
         mat_product = mat_product / mat_product[0, 0]
         assert qml.math.allclose(mat_product, qml.math.eye(mat_product.shape[0]))
@@ -91,7 +93,9 @@ class TestDecompositions:
     def test_parametric_decompositions(self, gate, decomp_function, angle):
         """Test decompositions of parametric operations."""
         expected_mat = gate.compute_matrix(angle)
-        obtained_mat = qml.matrix(decomp_function)(angle, wires=range(gate.num_wires))
+        obtained_mat = qml.matrix(decomp_function, wire_order=range(gate.num_wires))(
+            angle, wires=range(gate.num_wires)
+        )
         mat_product = qml.math.dot(expected_mat, qml.math.conj(qml.math.T(obtained_mat)))
         mat_product = mat_product / mat_product[0, 0]
         assert qml.math.allclose(mat_product, qml.math.eye(mat_product.shape[0]))
@@ -110,7 +114,7 @@ class TestDecompositions:
                 for op in obtained_decomp_list:
                     qml.apply(op)
 
-            obtained_matrix = qml.matrix(tape)
+            obtained_matrix = qml.matrix(tape, wire_order=tape.wires)
             mat_product = math.dot(obtained_matrix, math.conj(math.T(U)))
             mat_product = mat_product / mat_product[0, 0]
             assert math.allclose(mat_product, math.eye(2))

--- a/tests/test_transform_utils.py
+++ b/tests/test_transform_utils.py
@@ -1,6 +1,7 @@
 """
 Test the utility functions for the transpilation transforms. 
 """
+
 import pytest
 from functools import partial
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,6 +1,7 @@
 """
 Test the suite of transpilation transforms. 
 """
+
 import pytest
 from functools import partial
 
@@ -82,7 +83,10 @@ class TestCommuteThroughMSGates:
         expected_tape = qml.tape.make_qscript(expected_qfunc)()
 
         assert _compare_tape_contents(transformed_tape, expected_tape)
-        assert are_mats_equivalent(qml.matrix(transformed_tape), qml.matrix(expected_tape))
+        assert are_mats_equivalent(
+            qml.matrix(transformed_tape, wire_order=[0, 1]),
+            qml.matrix(expected_tape, wire_order=[0, 1]),
+        )
 
     def test_commutation_one_qubit(self):
         """Test case where gates on one of the qubits commutes."""
@@ -104,7 +108,10 @@ class TestCommuteThroughMSGates:
         expected_tape = qml.tape.make_qscript(expected_qfunc)()
 
         assert _compare_tape_contents(transformed_tape, expected_tape)
-        assert are_mats_equivalent(qml.matrix(transformed_tape), qml.matrix(expected_tape))
+        assert are_mats_equivalent(
+            qml.matrix(transformed_tape, wire_order=[0, 1]),
+            qml.matrix(expected_tape, wire_order=[0, 1]),
+        )
 
         def qfunc():
             MS(wires=[0, 1])
@@ -123,7 +130,10 @@ class TestCommuteThroughMSGates:
         expected_tape = qml.tape.make_qscript(expected_qfunc)()
 
         assert _compare_tape_contents(transformed_tape, expected_tape)
-        assert are_mats_equivalent(qml.matrix(transformed_tape), qml.matrix(expected_tape))
+        assert are_mats_equivalent(
+            qml.matrix(transformed_tape, wire_order=[0, 1]),
+            qml.matrix(expected_tape, wire_order=[0, 1]),
+        )
 
     def test_commutation_one_qubit_multiple_ms(self):
         """Test case where gates on one of the qubits commutes through multiple MS gates."""
@@ -145,7 +155,10 @@ class TestCommuteThroughMSGates:
         expected_tape = qml.tape.make_qscript(expected_qfunc)()
 
         assert _compare_tape_contents(transformed_tape, expected_tape)
-        assert are_mats_equivalent(qml.matrix(transformed_tape), qml.matrix(expected_tape))
+        assert are_mats_equivalent(
+            qml.matrix(transformed_tape, wire_order=range(3)),
+            qml.matrix(expected_tape, wire_order=range(3)),
+        )
 
     def test_commutation_two_qubits_multiple_ms(self):
         """Test case where gates on one of the qubits commutes."""
@@ -169,7 +182,10 @@ class TestCommuteThroughMSGates:
         expected_tape = qml.tape.make_qscript(expected_qfunc)()
 
         assert _compare_tape_contents(transformed_tape, expected_tape)
-        assert are_mats_equivalent(qml.matrix(transformed_tape), qml.matrix(expected_tape))
+        assert are_mats_equivalent(
+            qml.matrix(transformed_tape, wire_order=range(3)),
+            qml.matrix(expected_tape, wire_order=range(3)),
+        )
 
     def test_commutation_two_qubits_multiple_ms_left(self):
         """Test case where gates on one of the qubits commutes in leftward direction."""
@@ -211,7 +227,9 @@ class TestVirtualizeRZGates:
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert len(transformed_tape.operations) == 1
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=[0]), qml.matrix(transformed_tape, wire_order=[0])
+        )
 
     def test_rz_gpi2(self):
         """Test that RZ is correctly pushed through a GPI2 gate."""
@@ -229,7 +247,9 @@ class TestVirtualizeRZGates:
         assert all(
             op.name == name for op, name in zip(transformed_tape.operations, ["GPI2", "GPI", "GPI"])
         )
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=[0]), qml.matrix(transformed_tape, wire_order=[0])
+        )
 
     def test_rz_gpi_ms(self):
         """Test that non-GPI gates stop RZ from going through."""
@@ -249,7 +269,9 @@ class TestVirtualizeRZGates:
             op.name == name
             for op, name in zip(transformed_tape.operations, ["GPI2", "GPI", "GPI", "MS"])
         )
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=[0, 1]), qml.matrix(transformed_tape, wire_order=[0, 1])
+        )
 
     def test_rz_gpi_multiqubit(self):
         """Test that RZ gates are virtualized on multiple qubits."""
@@ -270,7 +292,9 @@ class TestVirtualizeRZGates:
             op.name == name
             for op, name in zip(transformed_tape.operations, ["GPI2", "GPI", "GPI", "GPI"])
         )
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=[0, 1]), qml.matrix(transformed_tape, wire_order=[0, 1])
+        )
 
     def test_rz_gpi_multiqubit_multims(self):
         """Test that RZ gates are virtualized on multiple qubits with gates in between."""
@@ -295,7 +319,9 @@ class TestVirtualizeRZGates:
                 transformed_tape.operations, ["GPI2", "GPI", "GPI", "MS", "GPI", "MS"]
             )
         )
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=[0, 1]), qml.matrix(transformed_tape, wire_order=[0, 1])
+        )
 
 
 class TestSingleQubitGPIFusion:
@@ -319,7 +345,9 @@ class TestSingleQubitGPIFusion:
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert _compare_tape_contents(tape, transformed_tape)
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=range(3)), qml.matrix(transformed_tape, wire_order=range(3))
+        )
 
     def test_no_fusion_multiple_gates(self):
         """Test that if there are no gates to fuse that nothing happens, even
@@ -341,7 +369,9 @@ class TestSingleQubitGPIFusion:
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert _compare_tape_contents(tape, transformed_tape)
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=range(3)), qml.matrix(transformed_tape, wire_order=range(3))
+        )
 
     def test_fusion_three_gates(self):
         """Test that if a GPI2/GPI/GPI2 sequence already exists that we don't fuse."""
@@ -363,7 +393,9 @@ class TestSingleQubitGPIFusion:
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert _compare_tape_contents(tape, transformed_tape)
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=range(3)), qml.matrix(transformed_tape, wire_order=range(3))
+        )
 
     def test_fusion_four_gates(self):
         """Test that more than three gates get properly fused."""
@@ -389,7 +421,9 @@ class TestSingleQubitGPIFusion:
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert len(transformed_tape.operations) == len(tape.operations) - 2
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=range(3)), qml.matrix(transformed_tape, wire_order=range(3))
+        )
 
 
 class TestConvertToGPI:
@@ -410,7 +444,9 @@ class TestConvertToGPI:
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert all(op.name in ["GPI", "GPI2", "MS"] for op in transformed_tape.operations)
-        assert are_mats_equivalent(qml.matrix(tape), qml.matrix(transformed_tape))
+        assert are_mats_equivalent(
+            qml.matrix(tape, wire_order=range(3)), qml.matrix(transformed_tape, wire_order=range(3))
+        )
 
     def test_convert_tape_to_gpi_known_gates_exclusion(self):
         """Test that known gates are correctly converted to GPI gates and

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """
 Test utility functions.
 """
+
 import pytest
 
 import numpy as np


### PR DESCRIPTION
**Context:** Minor changes to the test suite to account for updates and deprecations in most recent versions of PennyLane.

**Description of the Change:** (above)

**Benefits:** No more deprecation warnings when running tests!

**Possible Drawbacks:** N/A

**Related GitHub Issues:** N/A
