### PR TITLE
Set default black lines

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest pylint
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
         python -m pip install .
     - name: Check for black formatting
       uses: psf/black@stable

--- a/ionizer/identity_hunter.py
+++ b/ionizer/identity_hunter.py
@@ -155,6 +155,8 @@ def lookup_gate_identity(gates):
             "Currently only 2- and 3-gate circuit identities on GPI/GPI2 gates are supported."
         )
 
+    gate_identities = {}
+
     if len(gates) == 2:
         try:
             with DOUBLE_IDENTITY_FILE.open("rb") as infile:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pylint==3.1
-pytest==
+pytest==8.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pylint==3.1
+pytest==

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
 
 setup(
     name="Ionizer",
-    version="0.2",
+    version="0.3",
     description="PennyLane tools for compilation into trapped-ion native gates.",
     author="UBC Quantum Software and Algorithms Research Group",
     url="https://github.com/QSAR-UBC/ionizer",


### PR DESCRIPTION
**Context:**
The required line-length for this project is not the same as the default line length for black. It would be easier if default was set.

**Description of the Change:**
Added pyproject.toml file that sets default line length for black.

**Benefits:**
Easier to format code. Also, it is less confusing for other contributors to pass CI tests as they may not know the intended line length.

**Possible Drawbacks:**
Extra file in main folder.

**Related GitHub Issues:**
N/A