### PR TITLE
Add equivalence checking mechanism to transforms and tests

### DIFF
--- a/ionizer/transforms.py
+++ b/ionizer/transforms.py
@@ -20,11 +20,10 @@ The main transform in this module, :func:`ionizer.transforms.ionize`,
 performs end-to-end transpilation and optimization of circuits. It calls a
 number of helper transforms which can also be used individually.
 
-While all transforms should preserve the behaviour of the circuit, they contain
-a mechanism for under-the-hood equivalence checking (up to a global phase)
-through the ``verify_equivalence`` flag. When set, an error will be raised if
-the transpiled circuit is not equivalent to the original. This flag is ``False``
-by default as equivalence is checked at the unitary matrix level. For more details, see
+All transforms contain a mechanism for under-the-hood equivalence checking (up
+to a global phase) through the ``verify_equivalence`` flag. When set, an error
+will be raised if the transpiled circuit is not equivalent to the original. For
+details and example usage see :ref:`basic_usage-equivalence_validation` and
 :func:`ionizer.utils.flag_non_equivalence`.
 
 """

--- a/ionizer/utils.py
+++ b/ionizer/utils.py
@@ -18,6 +18,7 @@
 Utility functions.
 """
 
+import pennylane as qml
 import numpy as np
 from pennylane import math
 
@@ -52,6 +53,26 @@ def are_mats_equivalent(unitary1, unitary2):
             return True
 
     return False
+
+
+def flag_non_equivalence(tape1, tape2):
+    """Check equivalence of two circuits up to a global phase.
+
+    Args:
+        tape1 (pennylane.QuantumTape): a quantum tape
+        tape2 (pennylane.QuantumTape): quantum tape to compare with ``tape1``
+
+    Raises:
+        ValueError if the two circuits are not equivalent.
+    """
+    # Compute matrix representation using a consistent wire order
+    joint_wires = qml.wires.Wires.all_wires([tape1.wires, tape2.wires])
+    matrix_1 = qml.matrix(tape1, wire_order=joint_wires)
+    matrix_2 = qml.matrix(tape2, wire_order=joint_wires)
+
+    if not are_mats_equivalent(matrix_1, matrix_2):
+        raise ValueError("Quantum circuits are not equivalent after transform.")
+
 
 
 def rescale_angles(angles, renormalize_for_json=False):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -178,7 +178,8 @@ class TestCommuteThroughMSGates:
             qml.matrix(expected_tape, wire_order=range(3)),
         )
 
-    def test_commutation_two_qubits_multiple_ms_left(self):
+    @pytest.mark.parametrize("verify_equivalence", [True, False])
+    def test_commutation_two_qubits_multiple_ms_left(self, verify_equivalence):
         """Test case where gates on one of the qubits commutes in leftward direction."""
 
         def qfunc():
@@ -195,7 +196,9 @@ class TestCommuteThroughMSGates:
             GPI2(np.pi, wires=2)
             MS(wires=[0, 2])
 
-        transformed_qfunc = partial(commute_through_ms_gates, direction="left")(qfunc)
+        transformed_qfunc = partial(
+            commute_through_ms_gates, direction="left", verify_equivalence=verify_equivalence
+        )(qfunc)
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
         expected_tape = qml.tape.make_qscript(expected_qfunc)()
 
@@ -267,7 +270,8 @@ class TestVirtualizeRZGates:
             qml.matrix(transformed_tape, wire_order=[0, 1]),
         )
 
-    def test_rz_gpi_multiqubit(self):
+    @pytest.mark.parametrize("verify_equivalence", [True, False])
+    def test_rz_gpi_multiqubit(self, verify_equivalence):
         """Test that RZ gates are virtualized on multiple qubits."""
 
         def qfunc():
@@ -278,7 +282,9 @@ class TestVirtualizeRZGates:
 
         tape = qml.tape.make_qscript(qfunc)()
 
-        transformed_qfunc = virtualize_rz_gates(qfunc)
+        transformed_qfunc = partial(virtualize_rz_gates, verify_equivalence=verify_equivalence)(
+            qfunc
+        )
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert len(transformed_tape.operations) == 4
@@ -291,7 +297,8 @@ class TestVirtualizeRZGates:
             qml.matrix(transformed_tape, wire_order=[0, 1]),
         )
 
-    def test_rz_gpi_multiqubit_multims(self):
+    @pytest.mark.parametrize("verify_equivalence", [True, False])
+    def test_rz_gpi_multiqubit_multims(self, verify_equivalence):
         """Test that RZ gates are virtualized on multiple qubits with gates in between."""
 
         def qfunc():
@@ -304,7 +311,9 @@ class TestVirtualizeRZGates:
 
         tape = qml.tape.make_qscript(qfunc)()
 
-        transformed_qfunc = virtualize_rz_gates(qfunc)
+        transformed_qfunc = partial(virtualize_rz_gates, verify_equivalence=verify_equivalence)(
+            qfunc
+        )
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert len(transformed_tape.operations) == 6
@@ -396,7 +405,8 @@ class TestSingleQubitGPIFusion:
             qml.matrix(transformed_tape, wire_order=range(3)),
         )
 
-    def test_fusion_four_gates(self):
+    @pytest.mark.parametrize("verify_equivalence", [True, False])
+    def test_fusion_four_gates(self, verify_equivalence):
         """Test that more than three gates get properly fused."""
 
         def qfunc():
@@ -416,7 +426,9 @@ class TestSingleQubitGPIFusion:
 
         tape = qml.tape.make_qscript(qfunc)()
 
-        transformed_qfunc = single_qubit_fusion_gpi(qfunc)
+        transformed_qfunc = partial(single_qubit_fusion_gpi, verify_equivalence=verify_equivalence)(
+            qfunc
+        )
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert len(transformed_tape.operations) == len(tape.operations) - 2
@@ -429,7 +441,8 @@ class TestSingleQubitGPIFusion:
 class TestConvertToGPI:
     """Tests that operations on a tape are correctly converted to GPI gates."""
 
-    def test_convert_tape_to_gpi_known_gates(self):
+    @pytest.mark.parametrize("verify_equivalence", [True, False])
+    def test_convert_tape_to_gpi_known_gates(self, verify_equivalence):
         """Test that known gates are correctly converted to GPI gates."""
 
         def qfunc():
@@ -440,7 +453,7 @@ class TestConvertToGPI:
 
         tape = qml.tape.make_qscript(qfunc)()
 
-        transformed_qfunc = convert_to_gpi(qfunc)
+        transformed_qfunc = partial(convert_to_gpi, verify_equivalence=verify_equivalence)(qfunc)
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert all(op.name in ["GPI", "GPI2", "MS"] for op in transformed_tape.operations)
@@ -449,7 +462,8 @@ class TestConvertToGPI:
             qml.matrix(transformed_tape, wire_order=range(3)),
         )
 
-    def test_convert_tape_to_gpi_known_gates_exclusion(self):
+    @pytest.mark.parametrize("verify_equivalence", [True, False])
+    def test_convert_tape_to_gpi_known_gates_exclusion(self, verify_equivalence):
         """Test that known gates are correctly converted to GPI gates and
         excluded gates are kept as-is."""
 
@@ -461,7 +475,9 @@ class TestConvertToGPI:
 
         tape = qml.tape.make_qscript(qfunc)()
 
-        transformed_qfunc = partial(convert_to_gpi, exclude_list=["RY"])(qfunc)
+        transformed_qfunc = partial(
+            convert_to_gpi, exclude_list=["RY"], verify_equivalence=verify_equivalence
+        )(qfunc)
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
         assert all(op.name in ["GPI", "GPI2", "MS", "RY"] for op in transformed_tape.operations)
@@ -502,8 +518,7 @@ class TestIonize:
             qml.matrix(transformed_tape, wire_order=range(4)),
         )
 
-    @pytest.mark.parametrize("verify_equivalence", [True, False])
-    def test_ionize_qnode(self, verify_equivalence):
+    def test_ionize_qnode(self):
         """Test ionize transform on a QNode."""
         dev = qml.device("default.qubit", wires=5)
 
@@ -521,7 +536,7 @@ class TestIonize:
             return qml.expval(qml.PauliX(0) @ qml.PauliY(wires=1))
 
         @qml.qnode(dev)
-        @partial(ionize, verify_equivalence=verify_equivalence)
+        @ionize
         def ionized_qnode():
             quantum_function()
             return qml.expval(qml.PauliX(0) @ qml.PauliY(wires=1))
@@ -545,7 +560,8 @@ class TestIonize:
         ],
     )
     def test_ionize_parametrized_qnode(self, params, verify_equivalence):
-        """Test ionize transform on a QNode."""
+        """Test ionize transform on a QNode including parametrized gates.
+        Verify also that equivalence is preserved."""
         dev = qml.device("default.qubit", wires=5)
 
         def quantum_function(params):
@@ -572,7 +588,7 @@ class TestIonize:
 
         print(normal_qnode.qtape)
         print(ionized_qnode.qtape)
-        
+
         assert all(op.name in ["GPI", "GPI2", "MS"] for op in ionized_qnode.qtape.operations)
         assert are_mats_equivalent(
             qml.matrix(normal_qnode, wire_order=range(4))(params),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -510,8 +510,6 @@ class TestIonize:
         transformed_qfunc = ionize(qfunc, verify_equivalence=verify_equivalence)
         transformed_tape = qml.tape.make_qscript(transformed_qfunc)()
 
-        print(transformed_tape.operations)
-
         assert all(op.name in ["GPI", "GPI2", "MS"] for op in transformed_tape.operations)
         assert are_mats_equivalent(
             qml.matrix(tape, wire_order=range(4)),
@@ -585,9 +583,6 @@ class TestIonize:
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(wires=2))
 
         assert math.allclose(normal_qnode(params), ionized_qnode(params))
-
-        print(normal_qnode.qtape)
-        print(ionized_qnode.qtape)
 
         assert all(op.name in ["GPI", "GPI2", "MS"] for op in ionized_qnode.qtape.operations)
         assert are_mats_equivalent(


### PR DESCRIPTION
**Context:** Release v0.3 (new feature)

**Description of the Change:** Adds option for users to run background equivalence checking (up to global phase) for all transforms.

**Benefits:** Higher confidence that the transpiler is actually behaving correctly.

**Possible Drawbacks:** Equivalence is currently only verified up to global phase. 

**Related GitHub Issues:** #9 
